### PR TITLE
Fix insertion error, add more summary columns

### DIFF
--- a/mutation_analysis.py
+++ b/mutation_analysis.py
@@ -720,7 +720,7 @@ def summarize_for_nuc(df, group_name, iso_stats):
     return {
         'Analysis Type': label,
         'Total Positions': total_pos,
-        '#Isolates': n_iso,
+        'Total Isolates': n_iso,
         'Positions with Mutations': num_mut,
         'Percent Positions with Mutations': f"{perc_mut:.2f}",
         'Positions with >20% Mutations': num_high,
@@ -731,11 +731,11 @@ def summarize_for_nuc(df, group_name, iso_stats):
         'Total Deletions': del_total,
         'Total Stop Codons': stop_total,
         'Total Mutations': mut_total,
-        '#Isolate w/o synonymous mutation':     no_syn,
-        '#Isolate w/o non-synonymous mutation': no_nsyn,
-        '#Isolate w/o Insertion':               no_ins,
-        '#Isolate w/o Deletion':                no_del,
-        '#Isolate w/o Stop codons':             no_stop
+        'Isolate w/o synonymous mutation':     no_syn,
+        'Isolate w/o non-synonymous mutation': no_nsyn,
+        'Isolate w/o Insertion':               no_ins,
+        'Isolate w/o Deletion':                no_del,
+        'Isolate w/o Stop codons':             no_stop
     }
 
 
@@ -786,11 +786,11 @@ def summarize_for_prot(df, group_name, iso_stats):
         'Total Substitutions(Regular)': reg_sub_total,
         'Total Substitution(Frameshift)': total_frameshift,
         'Total Mutations':                total_mut,
-        '#Isolate w/o Substitution':      no_sub,
-        '#Isolate w/o Frameshift':        no_fs,
-        '#Isolate w/o Insertion':         no_ins,
-        '#Isolate w/o Deletion':          no_del,
-        '#Isolate w/o Stop codons':       no_stop
+        'Isolate w/o Substitution':      no_sub,
+        'Isolate w/o Frameshift':        no_fs,
+        'Isolate w/o Insertion':         no_ins,
+        'Isolate w/o Deletion':          no_del,
+        'Isolate w/o Stop codons':       no_stop
     }
 
 


### PR DESCRIPTION
There are function Fix + Minor improvement

Fix
1. If there is insertion ('-') exist within the reference genome, the codon number skip that position. So now there will be no single insertion event disrupt the whole alignment quality. 
2. Delete 'run_analysis_for_subset' function within the main function and now we reuse the existing function run_analysis_for_nucleotide and run_analysis_for_protein.
3. Save the protein alignment file within the result folder if user give nucleotide alignment file and ask for both result.
4. For the amino acid analysis sheet, if the (#deletion - #insertion)%3 != 0 (which is counted by net_indel parameter), then the substitution mutation will be counted as 'Substitution (Frameshift)' and stat will be calculated separately with regular substitution error. 

Minor improvement
1. Organised the comments so that there is no more '#NEW' comment
2. Add more summary stat with the total number of isolates for each group and number of isolate without each category of mutations
3. Add 'need_translate' parameter for checking if we need translation instead of running translation for each time
4. Sort the function parameters because we need net frameshift number and there is no more run_analysis_for_subset function. 